### PR TITLE
don't rely on Facter

### DIFF
--- a/lib/puppet/provider/fileshare/wmi.rb
+++ b/lib/puppet/provider/fileshare/wmi.rb
@@ -1,4 +1,4 @@
-require 'win32ole' if Facter['osfamily'].value == 'windows'
+require 'win32ole' rescue nil
 
 Puppet::Type.type(:fileshare).provide(:wmi) do
   desc "Manage Windows File Shares"


### PR DESCRIPTION
I'm not certain why this changed, but calling `Facter['thing']` is raising an exception in 2015.2.

```
Could not retrieve catalog from remote server: Error 400 on SERVER: Evaluation Error: Error while evaluating a Resource Statement, Could not autoload puppet/type/fileshare: Could not autoload puppet/provider/fileshare/wmi: undefined method `[]' for Facter:Module at /etc/puppetlabs/code/modules/classroom/manifests/windows/adserver.pp:48:3 on node adserver.puppetlabs.vm
```

This should functionally do the same thing at the cost of rescuing a load exception. I don't know that it's be _best_ solution :/
